### PR TITLE
Few updates

### DIFF
--- a/R/CorpusCoder.R
+++ b/R/CorpusCoder.R
@@ -74,6 +74,7 @@ CorpusCoder=function(Waves,Annotations,AnnotationType=c("TextGrid","ESPS"),TierN
         stop(paste0("TierName ",TierName," is not prestent in TextGrid:", Annotations[i]))
       }
       Part=TG[[which(TG[[1]]==TierName)+1]]
+      if(length(Part$Outcomes)<2) next
     }  
     Part$File=Waves[i]
     Part$Prev=c("<P>",Part$Outcomes[1:(length(Part$Outcomes)-1)])
@@ -82,6 +83,7 @@ CorpusCoder=function(Waves,Annotations,AnnotationType=c("TextGrid","ESPS"),TierN
         Part=Part[-grep(Dismiss,Part$Outcomes),]
       }
     }
+    if(length(Part$Outcomes)==0) next
     Wave=readWave(Waves[i])
     if(Wave@samp.rate!=16000){
       if(Wave@samp.rate<16000){

--- a/R/readAnnotation.R
+++ b/R/readAnnotation.R
@@ -19,16 +19,16 @@ readTextGridFast<-function(File,Encoding){
   Data=readLines(File,-1)
   close(File)
   
-  names=gsub("^[\\ ]+name\\ =\\ |\"|[\\ ]+","",Data[grep("name\ =",Data)])
+  names=gsub("^[[:space:]]+name\\ =\\ |\"|[\\ ]+","",Data[grep("name\ =",Data)])
   numberOfTiers=length(names)
   TierBorder=c(grep("IntervalTier|TextTier",Data),length(Data))
-  TierType=gsub("[\\ ]+|class|\\=|\"|-","",Data[grep("IntervalTier|TextTier",Data)])
+  TierType=gsub("[[:space:]]+|class|\\=|\"|-","",Data[grep("IntervalTier|TextTier",Data)])
   
   for(i in 1:numberOfTiers){
     if(TierType[i]=="IntervalTier"){
       Part=Data[TierBorder[i]:TierBorder[i+1]]
       Part=Part[-(1:5)]
-      Part=gsub("^[\\ ]+((text)|(xmin)|(xmax))\\ =\\ |\"|[\\ ]+$","",Part)
+      Part=gsub("^[[:space:]]+((text)|(xmin)|(xmax))\\ =\\ |\"|[\\ ]+$","",Part)
       Part=gsub("[\\ ]+$","",Part)
       if(length(grep("class\ =\ (IntervalTier)|(TextTier)",Part))>0){
         Part=Part[-grep("class\ =\ (IntervalTier)|(TextTier)",Part)]
@@ -44,7 +44,7 @@ readTextGridFast<-function(File,Encoding){
     else{
       Part=Data[TierBorder[i]:TierBorder[i+1]]
       Part=Part[-(1:5)]
-      Part=gsub("^[\\ ]+((mark)|(number))\\ =\\ |\"|[\\ ]+$","",Part)
+      Part=gsub("^[[:space:]]+((mark)|(number))\\ =\\ |\"|[\\ ]+$","",Part)
       Part=gsub("[\\ ]+$","",Part)
       if(length(grep("class\ =\ (IntervalTier)|(TextTier)",Part))>0){
         Part=Part[-grep("class\ =\ (IntervalTier)|(TextTier)",Part)]
@@ -88,16 +88,16 @@ readTextGridFast<-function(File,Encoding){
 readTextGridRobust<-function(File,Encoding){
   
   Data=read.csv(file(File,encoding=Encoding),stringsAsFactors=F,header=F)$V1
-  names=gsub("^[\\ ]+name\\ =\\ |\"|[\\ ]+","",Data[grep("name\ =",Data)])
+  names=gsub("^[[:space:]]+name\\ =\\ |\"|[\\ ]+","",Data[grep("name\ =",Data)])
   numberOfTiers=length(names)
   TierBorder=c(grep("IntervalTier|TextTier",Data),length(Data)+1)
-  TierType=gsub("[\\ ]+|class|\\=|\"|-","",Data[grep("IntervalTier|TextTier",Data)])
+  TierType=gsub("[[:space:]]+|class|\\=|\"|-","",Data[grep("IntervalTier|TextTier",Data)])
   
   for(i in 1:numberOfTiers){
     if(TierType[i]=="IntervalTier"){
       Part=Data[TierBorder[i]:(TierBorder[i+1]-1)]
       Part=Part[-(1:5)]
-      Part=gsub("^[\\ ]+((text)|(xmin)|(xmax))\\ =\\ |\"|[\\ ]+$","",Part)
+      Part=gsub("^[[:space:]]+((text)|(xmin)|(xmax))\\ =\\ |\"|[\\ ]+$","",Part)
       Part=gsub("[\\ ]+$","",Part)
       PartDataFrame=data.frame(Outcomes=character(),start=numeric(),end=numeric(),stringsAsFactors=F)
       for(j in 1:(length(Part)/4)){
@@ -113,7 +113,7 @@ readTextGridRobust<-function(File,Encoding){
     else{
       Part=Data[TierBorder[i]:(TierBorder[i+1]-1)]
       Part=Part[-(1:5)]
-      Part=gsub("^[\\ ]+((mark)|(number))\\ =\\ |\"|[\\ ]+$","",Part)
+      Part=gsub("^[[:space:]]+((mark)|(number))\\ =\\ |\"|[\\ ]+$","",Part)
       Part=gsub("[\\ ]+$","",Part)
       PartDataFrame=data.frame(Outcomes="",point=0,stringsAsFactors=F)
       for(j in 1:(length(Part)/3)){


### PR DESCRIPTION
1. in readTextGrid functions:
I changed the spaces in regular expressions to occurrence of any whitespace character.
Because, I work with TextGrid files not created by Praat itself, but by a python library called tgt (TextGrid Tools), which uses tabs instead of spaces in producing the annotations in textgrid format.

2. in CorpusCoder function:
Added two "if" conditions to take care of special cases where the input signal is too short, or consists of only music without speech, or all the spoken words are removed because of the dismiss option.